### PR TITLE
non-superusers user creation requires input from command line.

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -79,7 +79,7 @@ setup_items.each do |setup|
       if user['superuser']
         "sudo -u postgres createuser -s #{user['username']};"
       else
-        "sudo -u postgres createuser #{user['username']};"
+        "sudo -u postgres createuser -S #{user['username']};"
       end
     end
 


### PR DESCRIPTION
Creating a user without the superuser option set results in creatuser asking if you want superuser via stdin/stdout.   Add -S option to avoid this.